### PR TITLE
Don't rely on the "moola" petname; use the brand registry key

### DIFF
--- a/ui/public/src/wallet.js
+++ b/ui/public/src/wallet.js
@@ -2,10 +2,9 @@
 
 import dappConstants from '../lib/constants.js';
 
-// const { encouragement: encouragementBrandRegKey } =
-// dappConstants.brandRegKeys;
-
-const encouragementBrandRegKey = '';
+// TODO: Allow multiple brands for tipping.
+const { Tip: tipBrandRegKey } = dappConstants.brandRegKeys;
+const allowedBrandRegKeys = [tipBrandRegKey];
 
 /**
  * @typedef {Object.<string, HTMLOptionElement>} Purse
@@ -114,11 +113,9 @@ const updateOptions = (key, existing, currents, names, selects) => {
  * @param {Object.<string, HTMLSelectElement>} selects
  */
 export function walletUpdatePurses(purses, selects) {
-
-  // FIXME: Currently, we can only give moola tips.
-  allPurses = purses.filter( ({ issuerPetname }) => (issuerPetname === 'moola'));
-  // allPurses = purses.sort(({ pursePetname: a }, { pursePetname: b }) =>
-  //   cmp(a, b));
+  allPurses = purses.filter(
+    ({ brandRegKey }) => !allowedBrandRegKeys || allowedBrandRegKeys.includes(brandRegKey)
+  ).sort(({ pursePetname: a }, { pursePetname: b }) => cmp(a, b));
 
   const newIssuers = allPurses.sort(({ issuerPetname: a }, { issuerPetname: b }) =>
     cmp(a, b));


### PR DESCRIPTION
Generalise support not to allow specifying `TIP_ISSUER_NAME=simoleans agoric deploy api/deploy.js` to specify "simoleans" instead of "moola".  Then fetch the deployer's wallet's issuer under that petname and use it with its brandRegKey.

This is because people's petnames for their purses or issuers are supposed to be able to vary per person.  In the future, it would be great to allow people to install any arbitrary issuer on the publicAPI before using it for tipping.