### PR TITLE
chore!: use new ses, via @agoric/install-ses

### DIFF
--- a/contract/test/test-contract.js
+++ b/contract/test/test-contract.js
@@ -1,3 +1,4 @@
+import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { test } from 'tape-promise/tape';
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "_agstate/agoric-servers"
   ],
   "devDependencies": {
+    "@agoric/install-ses": "^0.1.0",
     "eslint": "^6.8.0",
     "eslint-config-airbnb": "^18.0.1",
     "eslint-config-airbnb-base": "^14.0.0",


### PR DESCRIPTION
The new agoric-sdk Zoe can only run inside a SES environment. This uses
`@agoric/install-ses` to set that up. It must land after it can land after https://github.com/Agoric/agoric-sdk/pull/1216 lands.

It does not change how the dapp uses the Zoe APIs, so it can land before https://github.com/Agoric/agoric-sdk/pull/1201 lands.
