### PR TITLE
fix: update to new Zoe/spawner API

### DIFF
--- a/api/deploy.js
+++ b/api/deploy.js
@@ -164,7 +164,7 @@ export default async function deployApi(homePromise, { bundleSource, pathResolve
   console.log(`-- InstanceHandle Register Key: ${INSTANCE_REG_KEY}`);
   console.log(`-- ASSURANCE_ISSUER_REGKEY: ${ASSURANCE_ISSUER_REGKEY}`);
   console.log(`-- ASSURANCE_BRAND_REGKEY: ${ASSURANCE_BRAND_REGKEY}`);
-  console.log(`-- TIP_BRAND_REGKEY: ${TIP_BRAND_REGKEY}`)
+  console.log(`-- TIP_BRAND_REGKEY: ${TIP_BRAND_REGKEY}`);
 
   // We want the handler to run persistently. (Scripts such as this
   // deploy.js script are ephemeral and all connections to objects
@@ -173,10 +173,10 @@ export default async function deployApi(homePromise, { bundleSource, pathResolve
   // the code on this machine even when the script is done running.
 
   // Bundle up the handler code
-  const { source, moduleFormat } = await bundleSource(pathResolve('./src/handler.js'));
+  const bundle = await bundleSource(pathResolve('./src/handler.js'));
   
   // Install it on the spawner
-  const handlerInstall = E(spawner).install(source, moduleFormat);
+  const handlerInstall = E(spawner).install(bundle);
 
   // Spawn the running code
   const handler = E(handlerInstall).spawn({ publicAPI, http });

--- a/contract/deploy.js
+++ b/contract/deploy.js
@@ -48,10 +48,8 @@ export default async function deployContract(
   // and install it on Zoe. This returns an installationHandle, an
   // opaque, unforgeable identifier for our contract code that we can
   // reuse again and again to create new, live contract instances.
-  const { source, moduleFormat } = await bundleSource(
-    pathResolve(`./src/contract.js`),
-  );
-  const installationHandle = await E(zoe).install(source, moduleFormat);
+  const bundle = await bundleSource(pathResolve(`./src/contract.js`));
+  const installationHandle = await E(zoe).install(bundle);
 
   // Let's share this installationHandle with other people, so that
   // they can run our encouragement contract code by making a contract

--- a/contract/test/test-contract.js
+++ b/contract/test/test-contract.js
@@ -18,7 +18,7 @@ test('contract with valid offers', async t => {
   try {
     // Outside of tests, we should use the long-lived Zoe on the
     // testnet. In this test, we must create a new Zoe.
-    const zoe = makeZoe({ require });
+    const zoe = makeZoe();
 
     // Get the Zoe invite issuer from Zoe.
     const inviteIssuer = await E(zoe).getInviteIssuer();
@@ -27,18 +27,19 @@ test('contract with valid offers', async t => {
     const getInstanceHandle = makeGetInstanceHandle(inviteIssuer);
 
     // Pack the contract.
-    const { source, moduleFormat } = await bundleSource(contractPath);
+    const contractBundle = await bundleSource(contractPath);
 
     // Install the contract on Zoe, getting an installationHandle (an
     // opaque identifier). We can use this installationHandle to look
     // up the code we installed. Outside of tests, we can also send the
     // installationHandle to someone else, and they can use it to
     // create a new contract instance using the same code.
-    const installationHandle = await E(zoe).install(source, moduleFormat);
+    const installationHandle = await E(zoe).install(contractBundle);
 
     // Let's check the code. Outside of this test, we would probably
     // want to check more extensively,
-    const code = await E(zoe).getInstallation(installationHandle);
+    const installedBundle = await E(zoe).getInstallation(installationHandle);
+    const code = installedBundle.source;
     t.ok(
       code.includes(`This contract does a few interesting things.`),
       `the code installed passes a quick check of what we intended to install`,


### PR DESCRIPTION
The agoric-sdk repo has been updated to use new-SES (see
https://github.com/Agoric/agoric-sdk/pull/1201 for details).

This changes the Zoe and spawner APIs: `zoe~.install(bundle)` instead of
`zoe~.install(source, moduleFormat)`, and `zoe.getInstallation` returns the
bundle object instead of a single string (so you must use a deep-equality
predicate).

The APIs are backwards-compatible, for now, but eventually support for the
old two-argument install() calls will be removed.

This should not land until after Agoric/agoric-sdk#1201 lands, but it does not need to land right away, because Zoe's API retains backwards compatibility for now.
