### PR TITLE
fix: WIP upgrade to new notifier API

### DIFF
--- a/api/src/handler.js
+++ b/api/src/handler.js
@@ -32,7 +32,7 @@ export default harden(({ publicAPI, http, board, inviteIssuer }, _inviteMaker) =
 
     // Wait until the next notification resolves.
     E(notifier)
-      .getUpdateSince(updateResponse.updateHandle)
+      .getUpdateSince(updateResponse.updateCount)
       .then(doOneNotification, fail);
   };
 
@@ -60,7 +60,7 @@ export default harden(({ publicAPI, http, board, inviteIssuer }, _inviteMaker) =
           // These are messages we receive from either POST or WebSocket.
           switch (obj.type) {
             case 'encouragement/getEncouragement': {
-              
+
               return harden({
                 type: 'encouragement/getEncouragementResponse',
                 data: await E(publicAPI).getFreeEncouragement(),
@@ -68,7 +68,7 @@ export default harden(({ publicAPI, http, board, inviteIssuer }, _inviteMaker) =
             }
 
             case 'encouragement/subscribeNotifications': {
-              
+
               return harden({
                 type: 'encouragement/subscribeNotificationsResponse',
                 data: true,
@@ -84,7 +84,7 @@ export default harden(({ publicAPI, http, board, inviteIssuer }, _inviteMaker) =
               const inviteHandleBoardId = await E(board).getId(handle);
               const updatedOffer = { ...offer, inviteHandleBoardId };
               E(depositFacet).receive(invite);
-              
+
               return harden({
                 type: 'encouragement/sendInviteResponse',
                 data: { offer: updatedOffer },

--- a/contract/src/contract.js
+++ b/contract/src/contract.js
@@ -1,7 +1,7 @@
 // @ts-check
 import harden from '@agoric/harden';
 import makeIssuerKit from '@agoric/ertp';
-import { produceNotifier } from '@agoric/notifier';
+import { makeNotifierKit } from '@agoric/notifier';
 import { makeZoeHelpers } from '@agoric/zoe/src/contractSupport/zoeHelpers';
 
 /**
@@ -16,7 +16,7 @@ const makeContract = zcf => {
     basic: `You're doing great!`,
     premium: `Wow, just wow. I have never seen such talent!`,
   };
-  const { notifier, updater } = produceNotifier();
+  const { notifier, updater } = makeNotifierKit(undefined);
   let adminOfferHandle;
 
   const { escrowAndAllocateTo, rejectOffer } = makeZoeHelpers(zcf);

--- a/contract/test/test-contract.js
+++ b/contract/test/test-contract.js
@@ -103,8 +103,8 @@ test('contract with valid offers', async t => {
     // to, in order to get updates about changes to the state of the
     // contract.
     const notifier = E(publicAPI).getNotifier();
-    const { value, updateHandle } = await E(notifier).getUpdateSince();
-    const nextUpdateP = E(notifier).getUpdateSince(updateHandle);
+    const { value, updateCount } = await E(notifier).getUpdateSince();
+    const nextUpdateP = E(notifier).getUpdateSince(updateCount);
 
     // Count starts at 0
     t.equals(value.count, 0, `count starts at 0`);


### PR DESCRIPTION
Upgrade dapp-encouragement to use the non-deprecated API introduced in https://github.com/Agoric/agoric-sdk/pull/1332 . 

That PR included legacy support so dapp-encouragement does not yet break. Once all clients are so upgraded, we will remove that legacy support from notifier.js.